### PR TITLE
FEATURE: see source TS plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,8 @@ meteor-rpc ships a TypeScript language server plugin that redirects **Go to Defi
 
 ### Setup
 
+having installed `meteor-rpc-ts-plugin` and added it to `tsconfig.json` (see below), you should be able to jump from client calls to server definitions immediately. If not, try restarting the TS server (command palette → **"TypeScript: Restart TS Server"**).
+
 **1. Add the plugin to your `tsconfig.json`**
 
 ```json
@@ -404,8 +406,6 @@ meteor-rpc ships a TypeScript language server plugin that redirects **Go to Defi
   }
 }
 ```
-
-The compiled plugin ships inside the `meteor-rpc` npm package, so no extra install is needed.
 
 **2. VS Code only — switch to workspace TypeScript**
 

--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ meteor-rpc ships a TypeScript language server plugin that redirects **Go to Defi
 ```json
 {
   "compilerOptions": {
-    "plugins": [{ "name": "meteor-rpc/ts-server-plugin" }]
+    "plugins": [{ "name": "meteor-rpc" }]
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -405,11 +405,7 @@ meteor-rpc ships a TypeScript language server plugin that redirects **Go to Defi
 }
 ```
 
-The compiled plugin ships inside the `meteor-rpc` npm package, so no extra install is needed. If you installed meteor-rpc only via Atmosphere (`meteor add grubba:rpc`) without the npm install, run:
-
-```bash
-meteor npm i meteor-rpc
-```
+The compiled plugin ships inside the `meteor-rpc` npm package, so no extra install is needed.
 
 **2. VS Code only — switch to workspace TypeScript**
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This package provides functions for building E2E type-safe RPCs.
 ## How to download it?
 
 ```bash
-meteor npm i meteor-rpc @tanstack/react-query zod
+meteor npm i meteor-rpc meteor-rpc-ts-plugin @tanstack/react-query zod
 ```
 
 install react query into your project, following their [quick start guide](https://tanstack.com/query/latest/docs/framework/react/quick-start)
@@ -400,7 +400,7 @@ meteor-rpc ships a TypeScript language server plugin that redirects **Go to Defi
 ```json
 {
   "compilerOptions": {
-    "plugins": [{ "name": "meteor-rpc" }]
+    "plugins": [{ "name": "meteor-rpc-ts-plugin" }]
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -388,3 +388,46 @@ server.name.addErrorResolveHook((err, raw, parsed) => {
 
 server = server.build();
 ```
+
+## Go to Definition (TypeScript Server Plugin)
+
+meteor-rpc ships a TypeScript language server plugin that redirects **Go to Definition** (`F12` / `Ctrl+B`) from a client call site directly to the matching `addMethod` / `createMethod` / `addPublication` call on the server — no code changes required.
+
+### Setup
+
+**1. Add the plugin to your `tsconfig.json`**
+
+```json
+{
+  "compilerOptions": {
+    "plugins": [{ "name": "meteor-rpc/ts-server-plugin" }]
+  }
+}
+```
+
+The compiled plugin ships inside the `meteor-rpc` npm package, so no extra install is needed. If you installed meteor-rpc only via Atmosphere (`meteor add grubba:rpc`) without the npm install, run:
+
+```bash
+meteor npm i meteor-rpc
+```
+
+**2. VS Code only — switch to workspace TypeScript**
+
+VS Code uses its own bundled TypeScript by default and ignores `tsconfig.json` plugins until you switch:
+
+1. Open the command palette (`Cmd+Shift+P` / `Ctrl+Shift+P`).
+2. Run **"TypeScript: Select TypeScript Version"**.
+3. Choose **"Use Workspace Version"**.
+
+This writes one line to `.vscode/settings.json` and is a one-time step. Other editors (Cursor, Neovim + tsserver, WebStorm) pick up `tsconfig.json` plugins automatically.
+
+### Result
+
+```typescript
+const app = createClient<Server>();
+
+app.bar("str");      // F12 on `bar`      → jumps to .addMethod("bar", ...)
+app.chat.createChat(); // F12 on `createChat` → jumps to .addMethod("createChat", ...)
+```
+
+Works with `addMethod`, `addPublication`, `addSharedPublication`, `createMethod`, `createQuery`, `createMutation`, `createPublication`, `createRealtimeQuery`, and `createSharedRealtimeQuery`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meteor-rpc",
-  "version": "1.1.0",
+  "version": "1.2.0-beta.0",
   "private": false,
   "description": "RPC e2e safe",
   "devDependencies": {
@@ -12,7 +12,9 @@
   "scripts": {
     "check-types": "npm install && tsc && tsd ./tests",
     "postcheck-types": "npm prune --prod",
-    "test": "meteor test-packages ./ "
+    "test": "meteor test-packages ./ ",
+    "build:plugin": "cd ts-server-plugin && npm install && npm run build",
+    "prepublishOnly": "npm run build:plugin"
   },
   "main": "server-main.ts",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meteor-rpc",
-  "version": "1.2.0-beta.0",
+  "version": "1.2.0-beta.1",
   "private": false,
   "description": "RPC e2e safe",
   "devDependencies": {
@@ -12,9 +12,7 @@
   "scripts": {
     "check-types": "npm install && tsc && tsd ./tests",
     "postcheck-types": "npm prune --prod",
-    "test": "meteor test-packages ./ ",
-    "build:plugin": "cd ts-server-plugin && npm install && npm run build",
-    "prepublishOnly": "npm run build:plugin"
+    "test": "meteor test-packages ./ "
   },
   "main": "server-main.ts",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meteor-rpc",
-  "version": "1.2.0-beta.5",
+  "version": "1.1.0",
   "private": false,
   "description": "RPC e2e safe",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meteor-rpc",
-  "version": "1.2.0-beta.1",
+  "version": "1.2.0-beta.2",
   "private": false,
   "description": "RPC e2e safe",
   "devDependencies": {
@@ -12,7 +12,9 @@
   "scripts": {
     "check-types": "npm install && tsc && tsd ./tests",
     "postcheck-types": "npm prune --prod",
-    "test": "meteor test-packages ./ "
+    "test": "meteor test-packages ./ ",
+    "build:plugin": "cd ts-server-plugin && npm install && npm run build",
+    "prepublishOnly": "npm run build:plugin"
   },
   "main": "server-main.ts",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meteor-rpc",
-  "version": "1.2.0-beta.2",
+  "version": "1.2.0-beta.4",
   "private": false,
   "description": "RPC e2e safe",
   "devDependencies": {
@@ -16,7 +16,8 @@
     "build:plugin": "cd ts-server-plugin && npm install && npm run build",
     "prepublishOnly": "npm run build:plugin"
   },
-  "main": "server-main.ts",
+  "main": "ts-server-plugin/dist/index.js",
+  "types": "server-main.ts",
   "license": "MIT",
   "dependencies": {
     "@tanstack/react-query": "^5.61.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meteor-rpc",
-  "version": "1.2.0-beta.4",
+  "version": "1.2.0-beta.5",
   "private": false,
   "description": "RPC e2e safe",
   "devDependencies": {
@@ -12,12 +12,9 @@
   "scripts": {
     "check-types": "npm install && tsc && tsd ./tests",
     "postcheck-types": "npm prune --prod",
-    "test": "meteor test-packages ./ ",
-    "build:plugin": "cd ts-server-plugin && npm install && npm run build",
-    "prepublishOnly": "npm run build:plugin"
+    "test": "meteor test-packages ./ "
   },
-  "main": "ts-server-plugin/dist/index.js",
-  "types": "server-main.ts",
+  "main": "server-main.ts",
   "license": "MIT",
   "dependencies": {
     "@tanstack/react-query": "^5.61.0",

--- a/ts-server-plugin/README.md
+++ b/ts-server-plugin/README.md
@@ -17,27 +17,23 @@ If no match is found it falls back to the default TypeScript behavior silently.
 
 ## Setup
 
-### 1. Build the plugin (first time only)
+### 1. Install
 
 ```sh
-cd ts-server-plugin
-npm install
-npm run build
+meteor npm i meteor-rpc-ts-plugin
 ```
-
-This produces `ts-server-plugin/dist/index.js`, which is what tsserver loads.
 
 ### 2. Add the plugin to your project's `tsconfig.json`
 
 ```json
 {
   "compilerOptions": {
-    "plugins": [{ "name": "meteor-rpc" }]
+    "plugins": [{ "name": "meteor-rpc-ts-plugin" }]
   }
 }
 ```
 
-The plugin name resolves to the package's `ts-server-plugin/` folder via Node module resolution, so as long as `meteor-rpc` is installed in the project there is nothing else to install.
+The plugin is a standalone package — install it alongside `meteor-rpc`.
 
 ### 3. VS Code: switch to workspace TypeScript
 
@@ -92,14 +88,14 @@ The quickest way to verify the plugin is working:
 
 ### Confirming the plugin is loaded
 
-Open the command palette and run **"TypeScript: Open TS Server Log"**. Search the log for `meteor-rpc` — you should see a line like:
+Open the command palette and run **"TypeScript: Open TS Server Log"**. Search the log for `meteor-rpc-ts-plugin` — you should see a line like:
 
 ```
-Loading plugin meteor-rpc from ...
+Loading plugin meteor-rpc-ts-plugin from ...
 ```
 
 If the line is absent, tsserver has not found the plugin. Double-check that:
-- `npm run build` has been run and `dist/index.js` exists.
+- `meteor-rpc-ts-plugin` is installed (`node_modules/meteor-rpc-ts-plugin/` exists).
 - The `plugins` entry in `tsconfig.json` is under `compilerOptions`.
 - VS Code is set to use workspace TypeScript.
 

--- a/ts-server-plugin/README.md
+++ b/ts-server-plugin/README.md
@@ -32,7 +32,7 @@ This produces `ts-server-plugin/dist/index.js`, which is what tsserver loads.
 ```json
 {
   "compilerOptions": {
-    "plugins": [{ "name": "meteor-rpc/ts-server-plugin" }]
+    "plugins": [{ "name": "meteor-rpc" }]
   }
 }
 ```
@@ -95,7 +95,7 @@ The quickest way to verify the plugin is working:
 Open the command palette and run **"TypeScript: Open TS Server Log"**. Search the log for `meteor-rpc` — you should see a line like:
 
 ```
-Loading plugin meteor-rpc/ts-server-plugin from ...
+Loading plugin meteor-rpc from ...
 ```
 
 If the line is absent, tsserver has not found the plugin. Double-check that:

--- a/ts-server-plugin/README.md
+++ b/ts-server-plugin/README.md
@@ -1,0 +1,143 @@
+# meteor-rpc TypeScript Server Plugin
+
+Enables **Go to Definition** (`Ctrl+B` / `F12`) on Meteor RPC method and publication names in any editor that uses the TypeScript language server (VS Code, Cursor, Neovim + tsserver, WebStorm, etc.).
+
+When you place your cursor on a method name in a client call such as `app.foo.baz(123)` and trigger Go to Definition, the plugin redirects you to the matching `createMethod("foo.baz", ...)` or `addMethod("baz", ...)` call site rather than to the library types.
+
+## How it works
+
+The plugin wraps the TypeScript language service's `getDefinitionAndBoundSpan` handler. When triggered on an identifier, it:
+
+1. Resolves the identifier's type via the TypeScript type checker.
+2. Checks whether the type has a `config.name` property holding a string literal — the shape shared by `ReturnMethod<Name, ...>` and `ReturnSubscription<Name, ...>`.
+3. If found, searches all project source files for a `createMethod`, `createMutation`, `createQuery`, `createPublication`, `createRealtimeQuery`, `createSharedRealtimeQuery`, `addMethod`, `addPublication`, or `addSharedPublication` call whose first string argument matches that name.
+4. Returns the matching call site as the definition location.
+
+If no match is found it falls back to the default TypeScript behavior silently.
+
+## Setup
+
+### 1. Build the plugin (first time only)
+
+```sh
+cd ts-server-plugin
+npm install
+npm run build
+```
+
+This produces `ts-server-plugin/dist/index.js`, which is what tsserver loads.
+
+### 2. Add the plugin to your project's `tsconfig.json`
+
+```json
+{
+  "compilerOptions": {
+    "plugins": [{ "name": "meteor-rpc/ts-server-plugin" }]
+  }
+}
+```
+
+The plugin name resolves to the package's `ts-server-plugin/` folder via Node module resolution, so as long as `meteor-rpc` is installed in the project there is nothing else to install.
+
+### 3. VS Code: switch to workspace TypeScript
+
+VS Code uses its own bundled TypeScript by default and does **not** load `tsconfig.json` plugins until you switch to the workspace version.
+
+1. Open the command palette (`Cmd+Shift+P` / `Ctrl+Shift+P`).
+2. Run **"TypeScript: Select TypeScript Version"**.
+3. Choose **"Use Workspace Version"**.
+
+This is a one-time, per-project setting stored in `.vscode/settings.json`:
+
+```json
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}
+```
+
+Other editors (Cursor, Neovim + nvim-lspconfig/tsserver, WebStorm) pick up `tsconfig.json` plugins automatically without any extra step.
+
+## Usage
+
+Works with both the `createModule` builder API and direct `createMethod` calls:
+
+```typescript
+// server/api.ts
+const server = createModule()
+  .addMethod("bar", z.string(), (arg) => "bar" as const)
+  .addSubmodule(
+    createModule("foo")
+      .addMethod("baz", z.number(), (arg) => "baz" as const)
+      .buildSubmodule()
+  )
+  .build();
+
+export type Server = typeof server;
+
+// client.ts
+const app = createClient<Server>();
+
+app.bar("str");      // Ctrl+B on `bar`  → goes to .addMethod("bar",  ...)
+app.foo.baz(123);   // Ctrl+B on `baz`  → goes to .addMethod("baz",  ...)
+```
+
+## Testing locally
+
+The quickest way to verify the plugin is working:
+
+1. Build the plugin (`npm run build` inside `ts-server-plugin/`).
+2. In the project that uses `meteor-rpc`, ensure the `plugins` entry is in `tsconfig.json` and VS Code is using workspace TypeScript (see Setup).
+3. Reload the TS server: open the command palette and run **"TypeScript: Restart TS Server"**.
+4. Open a client file, place the cursor on a method name (e.g. `bar` in `app.bar(...)`), and press `F12` / `Ctrl+B`. You should land at the `addMethod("bar", ...)` call site on the server.
+
+### Confirming the plugin is loaded
+
+Open the command palette and run **"TypeScript: Open TS Server Log"**. Search the log for `meteor-rpc` — you should see a line like:
+
+```
+Loading plugin meteor-rpc/ts-server-plugin from ...
+```
+
+If the line is absent, tsserver has not found the plugin. Double-check that:
+- `npm run build` has been run and `dist/index.js` exists.
+- The `plugins` entry in `tsconfig.json` is under `compilerOptions`.
+- VS Code is set to use workspace TypeScript.
+
+## Debugging
+
+### Enable verbose tsserver logging
+
+Set the `TSS_LOG` environment variable before starting your editor:
+
+```sh
+# macOS / Linux
+TSS_LOG="-logToFile true -file /tmp/tsserver.log -level verbose" code .
+```
+
+Then tail the log while reproducing the issue:
+
+```sh
+tail -f /tmp/tsserver.log | grep -i "meteor-rpc\|getDefinition"
+```
+
+### Add temporary log lines to the plugin source
+
+The plugin has access to the tsserver logger via `info.project.projectService.logger`:
+
+```typescript
+info.project.projectService.logger.info(`[meteor-rpc] resolved name: ${methodName}`);
+```
+
+Rebuild (`npm run build`) and restart the TS server (`"TypeScript: Restart TS Server"`) to pick up changes.
+
+### Inspecting the resolved type
+
+If Go to Definition is not redirecting where expected, the most common cause is that the type checker is not resolving the type to a `ReturnMethod` / `ReturnSubscription`. Add a log line in `extractMethodName` to print the type string:
+
+```typescript
+info.project.projectService.logger.info(
+  `[meteor-rpc] type: ${checker.typeToString(type)}`
+);
+```
+
+This will show what type the cursor position resolves to, which makes it easy to see whether the `config.name` path is being traversed correctly.

--- a/ts-server-plugin/dist/index.d.ts
+++ b/ts-server-plugin/dist/index.d.ts
@@ -1,0 +1,7 @@
+declare function init(modules: {
+    typescript: typeof import("typescript/lib/tsserverlibrary");
+}): {
+    create: (info: ts.server.PluginCreateInfo) => ts.LanguageService;
+};
+export = init;
+//# sourceMappingURL=index.d.ts.map

--- a/ts-server-plugin/dist/index.d.ts.map
+++ b/ts-server-plugin/dist/index.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["../src/index.ts"],"names":[],"mappings":"AAiBA,iBAAS,IAAI,CAAC,OAAO,EAAE;IACrB,UAAU,EAAE,cAAc,gCAAgC,CAAC,CAAC;CAC7D;mBAGuB,EAAE,CAAC,MAAM,CAAC,gBAAgB;EAmKjD;AAED,SAAS,IAAI,CAAC"}

--- a/ts-server-plugin/dist/index.js
+++ b/ts-server-plugin/dist/index.js
@@ -1,0 +1,152 @@
+"use strict";
+// Function names that register a Meteor method/publication and take the name as the first argument
+const CREATOR_FUNCTIONS = new Set([
+    "createMethod",
+    "createMutation",
+    "createQuery",
+    "createPublication",
+    "createRealtimeQuery",
+    "createSharedRealtimeQuery",
+]);
+// Module builder methods that also take the name as the first argument
+const MODULE_METHODS = new Set([
+    "addMethod",
+    "addPublication",
+    "addSharedPublication",
+]);
+function init(modules) {
+    const ts = modules.typescript;
+    function create(info) {
+        // Build a pass-through proxy wrapping the real language service
+        const proxy = Object.create(null);
+        for (const k of Object.keys(info.languageService)) {
+            const x = info.languageService[k];
+            proxy[k] = (...args) => x.apply(info.languageService, args);
+        }
+        // Override Go-to-Definition to redirect method/publication name strings
+        // back to their createMethod / addMethod call sites.
+        proxy.getDefinitionAndBoundSpan = (fileName, position) => {
+            var _a, _b;
+            const prior = info.languageService.getDefinitionAndBoundSpan(fileName, position);
+            try {
+                const program = info.languageService.getProgram();
+                if (!program)
+                    return prior;
+                const sourceFile = program.getSourceFile(fileName);
+                if (!sourceFile)
+                    return prior;
+                // Find the AST node under the cursor
+                const node = getNodeAtPosition(sourceFile, position);
+                if (!node || !ts.isIdentifier(node))
+                    return prior;
+                const checker = program.getTypeChecker();
+                const symbol = checker.getSymbolAtLocation(node);
+                if (!symbol)
+                    return prior;
+                // Resolve the type and check if it carries a `config.name` literal —
+                // both ReturnMethod<Name, ...> and ReturnSubscription<Name, ...> have this.
+                const decl = (_a = symbol.valueDeclaration) !== null && _a !== void 0 ? _a : (_b = symbol.declarations) === null || _b === void 0 ? void 0 : _b[0];
+                if (!decl)
+                    return prior;
+                const type = checker.getTypeOfSymbolAtLocation(symbol, decl);
+                const methodName = extractMethodName(type, checker);
+                if (!methodName)
+                    return prior;
+                // Search the project for the matching registration call site
+                const definition = findDefinition(methodName, program, sourceFile);
+                if (!definition)
+                    return prior;
+                return {
+                    textSpan: ts.createTextSpanFromBounds(node.getStart(sourceFile), node.getEnd()),
+                    definitions: [definition],
+                };
+            }
+            catch (_e) {
+                // Never break the language service — fall back to default behaviour
+                return prior;
+            }
+        };
+        return proxy;
+        // -------------------------------------------------------------------------
+        // Helpers
+        // -------------------------------------------------------------------------
+        function getNodeAtPosition(sourceFile, position) {
+            function find(node) {
+                if (position >= node.getStart(sourceFile) &&
+                    position < node.getEnd()) {
+                    return ts.forEachChild(node, find) || node;
+                }
+                return undefined;
+            }
+            return find(sourceFile);
+        }
+        /**
+         * If `type` is ReturnMethod<Name, ...> or ReturnSubscription<Name, ...>,
+         * returns the literal string value of the `config.name` property.
+         */
+        function extractMethodName(type, checker) {
+            var _a, _b, _c, _d;
+            const configProp = type.getProperty("config");
+            if (!configProp)
+                return undefined;
+            const configDecl = (_a = configProp.valueDeclaration) !== null && _a !== void 0 ? _a : (_b = configProp.declarations) === null || _b === void 0 ? void 0 : _b[0];
+            if (!configDecl)
+                return undefined;
+            const configType = checker.getTypeOfSymbolAtLocation(configProp, configDecl);
+            const nameProp = configType.getProperty("name");
+            if (!nameProp)
+                return undefined;
+            const nameDecl = (_c = nameProp.valueDeclaration) !== null && _c !== void 0 ? _c : (_d = nameProp.declarations) === null || _d === void 0 ? void 0 : _d[0];
+            if (!nameDecl)
+                return undefined;
+            const nameType = checker.getTypeOfSymbolAtLocation(nameProp, nameDecl);
+            if (!nameType.isStringLiteral())
+                return undefined;
+            return nameType.value;
+        }
+        /**
+         * Walks all (non-declaration) source files in the program looking for a
+         * createMethod / addMethod / etc. call whose first argument matches
+         * `methodName`. Current file is searched first.
+         */
+        function findDefinition(methodName, program, currentFile) {
+            const otherFiles = program
+                .getSourceFiles()
+                .filter((f) => f !== currentFile && !f.isDeclarationFile);
+            for (const sourceFile of [currentFile, ...otherFiles]) {
+                const result = findInFile(sourceFile, methodName);
+                if (result)
+                    return result;
+            }
+            return undefined;
+        }
+        function findInFile(sourceFile, methodName) {
+            function visit(node) {
+                if (ts.isCallExpression(node)) {
+                    const callee = node.expression;
+                    const isTargetCall = (ts.isIdentifier(callee) && CREATOR_FUNCTIONS.has(callee.text)) ||
+                        (ts.isPropertyAccessExpression(callee) &&
+                            MODULE_METHODS.has(callee.name.text));
+                    if (isTargetCall && node.arguments.length > 0) {
+                        const firstArg = node.arguments[0];
+                        if (ts.isStringLiteral(firstArg) &&
+                            firstArg.text === methodName) {
+                            return {
+                                fileName: sourceFile.fileName,
+                                textSpan: ts.createTextSpanFromBounds(firstArg.getStart(sourceFile), firstArg.getEnd()),
+                                kind: ts.ScriptElementKind.functionElement,
+                                name: methodName,
+                                containerName: "",
+                                containerKind: ts.ScriptElementKind.unknown,
+                            };
+                        }
+                    }
+                }
+                return ts.forEachChild(node, visit);
+            }
+            return ts.forEachChild(sourceFile, visit);
+        }
+    }
+    return { create };
+}
+module.exports = init;

--- a/ts-server-plugin/dist/index.js
+++ b/ts-server-plugin/dist/index.js
@@ -17,6 +17,8 @@ const MODULE_METHODS = new Set([
 function init(modules) {
     const ts = modules.typescript;
     function create(info) {
+        const log = (msg) => info.project.projectService.logger.info(`[meteor-rpc] ${msg}`);
+        log(`plugin loaded (TypeScript ${ts.version})`);
         // Build a pass-through proxy wrapping the real language service
         const proxy = Object.create(null);
         for (const k of Object.keys(info.languageService)) {
@@ -30,32 +32,50 @@ function init(modules) {
             const prior = info.languageService.getDefinitionAndBoundSpan(fileName, position);
             try {
                 const program = info.languageService.getProgram();
-                if (!program)
+                if (!program) {
+                    log("getDefinition: no program");
                     return prior;
+                }
                 const sourceFile = program.getSourceFile(fileName);
-                if (!sourceFile)
+                if (!sourceFile) {
+                    log(`getDefinition: no sourceFile for ${fileName}`);
                     return prior;
+                }
                 // Find the AST node under the cursor
                 const node = getNodeAtPosition(sourceFile, position);
-                if (!node || !ts.isIdentifier(node))
+                if (!node || !ts.isIdentifier(node)) {
+                    log(`getDefinition: no identifier at position ${position}`);
                     return prior;
+                }
+                log(`getDefinition: identifier "${node.text}"`);
                 const checker = program.getTypeChecker();
                 const symbol = checker.getSymbolAtLocation(node);
-                if (!symbol)
+                if (!symbol) {
+                    log(`getDefinition: no symbol for "${node.text}"`);
                     return prior;
+                }
                 // Resolve the type and check if it carries a `config.name` literal —
                 // both ReturnMethod<Name, ...> and ReturnSubscription<Name, ...> have this.
                 const decl = (_a = symbol.valueDeclaration) !== null && _a !== void 0 ? _a : (_b = symbol.declarations) === null || _b === void 0 ? void 0 : _b[0];
-                if (!decl)
+                if (!decl) {
+                    log(`getDefinition: no declaration for "${node.text}"`);
                     return prior;
+                }
                 const type = checker.getTypeOfSymbolAtLocation(symbol, decl);
+                log(`getDefinition: type is "${checker.typeToString(type)}"`);
                 const methodName = extractMethodName(type, checker);
-                if (!methodName)
+                if (!methodName) {
+                    log(`getDefinition: type has no config.name — not a ReturnMethod/ReturnSubscription`);
                     return prior;
+                }
+                log(`getDefinition: resolved method name "${methodName}" — searching project files`);
                 // Search the project for the matching registration call site
                 const definition = findDefinition(methodName, program, sourceFile);
-                if (!definition)
+                if (!definition) {
+                    log(`getDefinition: no call site found for "${methodName}"`);
                     return prior;
+                }
+                log(`getDefinition: found call site in ${definition.fileName}`);
                 return {
                     textSpan: ts.createTextSpanFromBounds(node.getStart(sourceFile), node.getEnd()),
                     definitions: [definition],
@@ -63,6 +83,7 @@ function init(modules) {
             }
             catch (_e) {
                 // Never break the language service — fall back to default behaviour
+                log(`getDefinition: caught error — ${_e}`);
                 return prior;
             }
         };

--- a/ts-server-plugin/dist/index.js
+++ b/ts-server-plugin/dist/index.js
@@ -28,7 +28,6 @@ function init(modules) {
         // Override Go-to-Definition to redirect method/publication name strings
         // back to their createMethod / addMethod call sites.
         proxy.getDefinitionAndBoundSpan = (fileName, position) => {
-            var _a, _b;
             const prior = info.languageService.getDefinitionAndBoundSpan(fileName, position);
             try {
                 const program = info.languageService.getProgram();
@@ -49,28 +48,29 @@ function init(modules) {
                 }
                 log(`getDefinition: identifier "${node.text}"`);
                 const checker = program.getTypeChecker();
-                const symbol = checker.getSymbolAtLocation(node);
-                if (!symbol) {
-                    log(`getDefinition: no symbol for "${node.text}"`);
-                    return prior;
-                }
                 // Resolve the type and check if it carries a `config.name` literal —
                 // both ReturnMethod<Name, ...> and ReturnSubscription<Name, ...> have this.
-                const decl = (_a = symbol.valueDeclaration) !== null && _a !== void 0 ? _a : (_b = symbol.declarations) === null || _b === void 0 ? void 0 : _b[0];
-                if (!decl) {
-                    log(`getDefinition: no declaration for "${node.text}"`);
-                    return prior;
-                }
-                const type = checker.getTypeOfSymbolAtLocation(symbol, decl);
+                // Use getTypeAtLocation on the identifier node directly — this is the
+                // most reliable way to get the type of a property access in TS 4 and 5.
+                const type = checker.getTypeAtLocation(node);
                 log(`getDefinition: type is "${checker.typeToString(type)}"`);
-                const methodName = extractMethodName(type, checker);
+                const methodName = extractMethodName(type, checker, node);
                 if (!methodName) {
                     log(`getDefinition: type has no config.name — not a ReturnMethod/ReturnSubscription`);
                     return prior;
                 }
                 log(`getDefinition: resolved method name "${methodName}" — searching project files`);
+                // For submodule methods the full name is e.g. "example.exampleMethod"
+                // but the call site uses the local name "exampleMethod" inside createModule("example").
+                // Try the full name first, then fall back to the last dotted segment.
+                const localName = methodName.includes(".")
+                    ? methodName.slice(methodName.lastIndexOf(".") + 1)
+                    : methodName;
                 // Search the project for the matching registration call site
-                const definition = findDefinition(methodName, program, sourceFile);
+                const definition = findDefinition(methodName, program, sourceFile) ||
+                    (localName !== methodName
+                        ? findDefinition(localName, program, sourceFile)
+                        : undefined);
                 if (!definition) {
                     log(`getDefinition: no call site found for "${methodName}"`);
                     return prior;
@@ -105,25 +105,27 @@ function init(modules) {
          * If `type` is ReturnMethod<Name, ...> or ReturnSubscription<Name, ...>,
          * returns the literal string value of the `config.name` property.
          */
-        function extractMethodName(type, checker) {
-            var _a, _b, _c, _d;
+        function extractMethodName(type, checker, contextNode) {
             const configProp = type.getProperty("config");
             if (!configProp)
                 return undefined;
-            const configDecl = (_a = configProp.valueDeclaration) !== null && _a !== void 0 ? _a : (_b = configProp.declarations) === null || _b === void 0 ? void 0 : _b[0];
-            if (!configDecl)
-                return undefined;
-            const configType = checker.getTypeOfSymbolAtLocation(configProp, configDecl);
+            const configType = checker.getTypeOfSymbolAtLocation(configProp, contextNode);
             const nameProp = configType.getProperty("name");
             if (!nameProp)
                 return undefined;
-            const nameDecl = (_c = nameProp.valueDeclaration) !== null && _c !== void 0 ? _c : (_d = nameProp.declarations) === null || _d === void 0 ? void 0 : _d[0];
-            if (!nameDecl)
-                return undefined;
-            const nameType = checker.getTypeOfSymbolAtLocation(nameProp, nameDecl);
-            if (!nameType.isStringLiteral())
-                return undefined;
-            return nameType.value;
+            const nameType = checker.getTypeOfSymbolAtLocation(nameProp, contextNode);
+            // The Name type parameter may be a union like:
+            //   "createChatRoom" | `${string}.createChatRoom`
+            // Pick the first plain string-literal member from the union.
+            if (nameType.isStringLiteral())
+                return nameType.value;
+            if (nameType.isUnion()) {
+                for (const member of nameType.types) {
+                    if (member.isStringLiteral())
+                        return member.value;
+                }
+            }
+            return undefined;
         }
         /**
          * Walks all (non-declaration) source files in the program looking for a

--- a/ts-server-plugin/package-lock.json
+++ b/ts-server-plugin/package-lock.json
@@ -1,0 +1,30 @@
+{
+  "name": "meteor-rpc-ts-server-plugin",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "meteor-rpc-ts-server-plugin",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "^4.7.4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    }
+  }
+}

--- a/ts-server-plugin/package.json
+++ b/ts-server-plugin/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "meteor-rpc-ts-server-plugin",
+  "name": "meteor-rpc-ts-plugin",
   "version": "1.0.0",
   "description": "TypeScript language server plugin for meteor-rpc — enables Go-to-Definition on method/publication names",
   "main": "dist/index.js",

--- a/ts-server-plugin/package.json
+++ b/ts-server-plugin/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "meteor-rpc-ts-server-plugin",
+  "version": "1.0.0",
+  "description": "TypeScript language server plugin for meteor-rpc — enables Go-to-Definition on method/publication names",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc"
+  },
+  "devDependencies": {
+    "typescript": "^4.7.4"
+  },
+  "license": "MIT"
+}

--- a/ts-server-plugin/src/index.ts
+++ b/ts-server-plugin/src/index.ts
@@ -58,23 +58,32 @@ function init(modules: { typescript: typeof ts }) {
         log(`getDefinition: identifier "${node.text}"`);
 
         const checker = program.getTypeChecker();
-        const symbol = checker.getSymbolAtLocation(node);
-        if (!symbol) { log(`getDefinition: no symbol for "${node.text}"`); return prior; }
 
         // Resolve the type and check if it carries a `config.name` literal —
         // both ReturnMethod<Name, ...> and ReturnSubscription<Name, ...> have this.
-        const decl = symbol.valueDeclaration ?? symbol.declarations?.[0];
-        if (!decl) { log(`getDefinition: no declaration for "${node.text}"`); return prior; }
-        const type = checker.getTypeOfSymbolAtLocation(symbol, decl);
+        // Use getTypeAtLocation on the identifier node directly — this is the
+        // most reliable way to get the type of a property access in TS 4 and 5.
+        const type = checker.getTypeAtLocation(node);
         log(`getDefinition: type is "${checker.typeToString(type)}"`);
 
-        const methodName = extractMethodName(type, checker);
+        const methodName = extractMethodName(type, checker, node);
         if (!methodName) { log(`getDefinition: type has no config.name — not a ReturnMethod/ReturnSubscription`); return prior; }
 
         log(`getDefinition: resolved method name "${methodName}" — searching project files`);
 
+        // For submodule methods the full name is e.g. "example.exampleMethod"
+        // but the call site uses the local name "exampleMethod" inside createModule("example").
+        // Try the full name first, then fall back to the last dotted segment.
+        const localName = methodName.includes(".")
+          ? methodName.slice(methodName.lastIndexOf(".") + 1)
+          : methodName;
+
         // Search the project for the matching registration call site
-        const definition = findDefinition(methodName, program, sourceFile);
+        const definition =
+          findDefinition(methodName, program, sourceFile) ||
+          (localName !== methodName
+            ? findDefinition(localName, program, sourceFile)
+            : undefined);
         if (!definition) { log(`getDefinition: no call site found for "${methodName}"`); return prior; }
 
         log(`getDefinition: found call site in ${definition.fileName}`);
@@ -121,22 +130,28 @@ function init(modules: { typescript: typeof ts }) {
      */
     function extractMethodName(
       type: ts.Type,
-      checker: ts.TypeChecker
+      checker: ts.TypeChecker,
+      contextNode: ts.Node
     ): string | undefined {
       const configProp = type.getProperty("config");
       if (!configProp) return undefined;
-      const configDecl = configProp.valueDeclaration ?? configProp.declarations?.[0];
-      if (!configDecl) return undefined;
-      const configType = checker.getTypeOfSymbolAtLocation(configProp, configDecl);
+      const configType = checker.getTypeOfSymbolAtLocation(configProp, contextNode);
 
       const nameProp = configType.getProperty("name");
       if (!nameProp) return undefined;
-      const nameDecl = nameProp.valueDeclaration ?? nameProp.declarations?.[0];
-      if (!nameDecl) return undefined;
-      const nameType = checker.getTypeOfSymbolAtLocation(nameProp, nameDecl);
-      if (!nameType.isStringLiteral()) return undefined;
+      const nameType = checker.getTypeOfSymbolAtLocation(nameProp, contextNode);
 
-      return nameType.value;
+      // The Name type parameter may be a union like:
+      //   "createChatRoom" | `${string}.createChatRoom`
+      // Pick the first plain string-literal member from the union.
+      if (nameType.isStringLiteral()) return nameType.value;
+      if (nameType.isUnion()) {
+        for (const member of nameType.types) {
+          if (member.isStringLiteral()) return member.value;
+        }
+      }
+
+      return undefined;
     }
 
     /**

--- a/ts-server-plugin/src/index.ts
+++ b/ts-server-plugin/src/index.ts
@@ -21,6 +21,11 @@ function init(modules: { typescript: typeof ts }) {
   const ts = modules.typescript;
 
   function create(info: ts.server.PluginCreateInfo) {
+    const log = (msg: string) =>
+      info.project.projectService.logger.info(`[meteor-rpc] ${msg}`);
+
+    log(`plugin loaded (TypeScript ${ts.version})`);
+
     // Build a pass-through proxy wrapping the real language service
     const proxy: ts.LanguageService = Object.create(null);
     for (const k of Object.keys(info.languageService) as Array<
@@ -41,30 +46,38 @@ function init(modules: { typescript: typeof ts }) {
 
       try {
         const program = info.languageService.getProgram();
-        if (!program) return prior;
+        if (!program) { log("getDefinition: no program"); return prior; }
 
         const sourceFile = program.getSourceFile(fileName);
-        if (!sourceFile) return prior;
+        if (!sourceFile) { log(`getDefinition: no sourceFile for ${fileName}`); return prior; }
 
         // Find the AST node under the cursor
         const node = getNodeAtPosition(sourceFile, position);
-        if (!node || !ts.isIdentifier(node)) return prior;
+        if (!node || !ts.isIdentifier(node)) { log(`getDefinition: no identifier at position ${position}`); return prior; }
+
+        log(`getDefinition: identifier "${node.text}"`);
 
         const checker = program.getTypeChecker();
         const symbol = checker.getSymbolAtLocation(node);
-        if (!symbol) return prior;
+        if (!symbol) { log(`getDefinition: no symbol for "${node.text}"`); return prior; }
 
         // Resolve the type and check if it carries a `config.name` literal —
         // both ReturnMethod<Name, ...> and ReturnSubscription<Name, ...> have this.
         const decl = symbol.valueDeclaration ?? symbol.declarations?.[0];
-        if (!decl) return prior;
+        if (!decl) { log(`getDefinition: no declaration for "${node.text}"`); return prior; }
         const type = checker.getTypeOfSymbolAtLocation(symbol, decl);
+        log(`getDefinition: type is "${checker.typeToString(type)}"`);
+
         const methodName = extractMethodName(type, checker);
-        if (!methodName) return prior;
+        if (!methodName) { log(`getDefinition: type has no config.name — not a ReturnMethod/ReturnSubscription`); return prior; }
+
+        log(`getDefinition: resolved method name "${methodName}" — searching project files`);
 
         // Search the project for the matching registration call site
         const definition = findDefinition(methodName, program, sourceFile);
-        if (!definition) return prior;
+        if (!definition) { log(`getDefinition: no call site found for "${methodName}"`); return prior; }
+
+        log(`getDefinition: found call site in ${definition.fileName}`);
 
         return {
           textSpan: ts.createTextSpanFromBounds(
@@ -75,6 +88,7 @@ function init(modules: { typescript: typeof ts }) {
         };
       } catch (_e) {
         // Never break the language service — fall back to default behaviour
+        log(`getDefinition: caught error — ${_e}`);
         return prior;
       }
     };

--- a/ts-server-plugin/src/index.ts
+++ b/ts-server-plugin/src/index.ts
@@ -1,0 +1,192 @@
+import type * as ts from "typescript/lib/tsserverlibrary";
+
+// Function names that register a Meteor method/publication and take the name as the first argument
+const CREATOR_FUNCTIONS = new Set([
+  "createMethod",
+  "createMutation",
+  "createQuery",
+  "createPublication",
+  "createRealtimeQuery",
+  "createSharedRealtimeQuery",
+]);
+
+// Module builder methods that also take the name as the first argument
+const MODULE_METHODS = new Set([
+  "addMethod",
+  "addPublication",
+  "addSharedPublication",
+]);
+
+function init(modules: { typescript: typeof ts }) {
+  const ts = modules.typescript;
+
+  function create(info: ts.server.PluginCreateInfo) {
+    // Build a pass-through proxy wrapping the real language service
+    const proxy: ts.LanguageService = Object.create(null);
+    for (const k of Object.keys(info.languageService) as Array<
+      keyof ts.LanguageService
+    >) {
+      const x = info.languageService[k]!;
+      proxy[k] = (...args: Array<unknown>) =>
+        (x as Function).apply(info.languageService, args);
+    }
+
+    // Override Go-to-Definition to redirect method/publication name strings
+    // back to their createMethod / addMethod call sites.
+    proxy.getDefinitionAndBoundSpan = (fileName, position) => {
+      const prior = info.languageService.getDefinitionAndBoundSpan(
+        fileName,
+        position
+      );
+
+      try {
+        const program = info.languageService.getProgram();
+        if (!program) return prior;
+
+        const sourceFile = program.getSourceFile(fileName);
+        if (!sourceFile) return prior;
+
+        // Find the AST node under the cursor
+        const node = getNodeAtPosition(sourceFile, position);
+        if (!node || !ts.isIdentifier(node)) return prior;
+
+        const checker = program.getTypeChecker();
+        const symbol = checker.getSymbolAtLocation(node);
+        if (!symbol) return prior;
+
+        // Resolve the type and check if it carries a `config.name` literal —
+        // both ReturnMethod<Name, ...> and ReturnSubscription<Name, ...> have this.
+        const decl = symbol.valueDeclaration ?? symbol.declarations?.[0];
+        if (!decl) return prior;
+        const type = checker.getTypeOfSymbolAtLocation(symbol, decl);
+        const methodName = extractMethodName(type, checker);
+        if (!methodName) return prior;
+
+        // Search the project for the matching registration call site
+        const definition = findDefinition(methodName, program, sourceFile);
+        if (!definition) return prior;
+
+        return {
+          textSpan: ts.createTextSpanFromBounds(
+            node.getStart(sourceFile),
+            node.getEnd()
+          ),
+          definitions: [definition],
+        };
+      } catch (_e) {
+        // Never break the language service — fall back to default behaviour
+        return prior;
+      }
+    };
+
+    return proxy;
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    function getNodeAtPosition(
+      sourceFile: ts.SourceFile,
+      position: number
+    ): ts.Node | undefined {
+      function find(node: ts.Node): ts.Node | undefined {
+        if (
+          position >= node.getStart(sourceFile) &&
+          position < node.getEnd()
+        ) {
+          return ts.forEachChild(node, find) || node;
+        }
+        return undefined;
+      }
+      return find(sourceFile);
+    }
+
+    /**
+     * If `type` is ReturnMethod<Name, ...> or ReturnSubscription<Name, ...>,
+     * returns the literal string value of the `config.name` property.
+     */
+    function extractMethodName(
+      type: ts.Type,
+      checker: ts.TypeChecker
+    ): string | undefined {
+      const configProp = type.getProperty("config");
+      if (!configProp) return undefined;
+      const configDecl = configProp.valueDeclaration ?? configProp.declarations?.[0];
+      if (!configDecl) return undefined;
+      const configType = checker.getTypeOfSymbolAtLocation(configProp, configDecl);
+
+      const nameProp = configType.getProperty("name");
+      if (!nameProp) return undefined;
+      const nameDecl = nameProp.valueDeclaration ?? nameProp.declarations?.[0];
+      if (!nameDecl) return undefined;
+      const nameType = checker.getTypeOfSymbolAtLocation(nameProp, nameDecl);
+      if (!nameType.isStringLiteral()) return undefined;
+
+      return nameType.value;
+    }
+
+    /**
+     * Walks all (non-declaration) source files in the program looking for a
+     * createMethod / addMethod / etc. call whose first argument matches
+     * `methodName`. Current file is searched first.
+     */
+    function findDefinition(
+      methodName: string,
+      program: ts.Program,
+      currentFile: ts.SourceFile
+    ): ts.DefinitionInfo | undefined {
+      const otherFiles = program
+        .getSourceFiles()
+        .filter((f) => f !== currentFile && !f.isDeclarationFile);
+
+      for (const sourceFile of [currentFile, ...otherFiles]) {
+        const result = findInFile(sourceFile, methodName);
+        if (result) return result;
+      }
+      return undefined;
+    }
+
+    function findInFile(
+      sourceFile: ts.SourceFile,
+      methodName: string
+    ): ts.DefinitionInfo | undefined {
+      function visit(node: ts.Node): ts.DefinitionInfo | undefined {
+        if (ts.isCallExpression(node)) {
+          const callee = node.expression;
+          const isTargetCall =
+            (ts.isIdentifier(callee) && CREATOR_FUNCTIONS.has(callee.text)) ||
+            (ts.isPropertyAccessExpression(callee) &&
+              MODULE_METHODS.has(callee.name.text));
+
+          if (isTargetCall && node.arguments.length > 0) {
+            const firstArg = node.arguments[0];
+            if (
+              ts.isStringLiteral(firstArg) &&
+              firstArg.text === methodName
+            ) {
+              return {
+                fileName: sourceFile.fileName,
+                textSpan: ts.createTextSpanFromBounds(
+                  firstArg.getStart(sourceFile),
+                  firstArg.getEnd()
+                ),
+                kind: ts.ScriptElementKind.functionElement,
+                name: methodName,
+                containerName: "",
+                containerKind: ts.ScriptElementKind.unknown,
+              };
+            }
+          }
+        }
+
+        return ts.forEachChild(node, visit);
+      }
+
+      return ts.forEachChild(sourceFile, visit);
+    }
+  }
+
+  return { create };
+}
+
+export = init;

--- a/ts-server-plugin/tsconfig.json
+++ b/ts-server-plugin/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "module": "commonjs",
+    "lib": ["ES2017"],
+    "strict": true,
+    "outDir": "./dist",
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## How to test:
Get an example repo that uses meteor-rpc:

- https://github.com/Grubba27/testing-meteor-rpc
- run `npm i meteor-rpc-ts-plugin`
-  add `    "plugins": [{ "name": "meteor-rpc-ts-plugin" }],` to your tsconfig.json
- restart your ts server

Your app should work like this: 

https://github.com/user-attachments/assets/d258dfdb-0e1c-461e-84de-18d27db2f1ab